### PR TITLE
Include rspec

### DIFF
--- a/hippo_xml_parser.gemspec
+++ b/hippo_xml_parser.gemspec
@@ -4,22 +4,23 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hippo_xml_parser/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "hippo_xml_parser"
+  spec.name          = 'hippo_xml_parser'
   spec.version       = HippoXmlParser::VERSION
-  spec.authors       = ["Jared Fraser"]
-  spec.email         = ["dev@jsf.io"]
+  spec.authors       = ['Jared Fraser']
+  spec.email         = ['dev@jsf.io']
   spec.summary       = %q{Parser for Hippo XML exports}
   spec.description   = %q{}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "nokogiri"
+  spec.add_dependency 'nokogiri'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '~> 3.1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'hippo_xml_parser'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Simple thing, just tried to run the specs after a bundle install and the rspec was not installed because the rspec was not included in the gemspec. So the PR includes rspec in the gemspec.
